### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,6 +9,7 @@
   ],
   "description" : "consume MetaCPAN recent favorite",
   "name" : "MetaCPAN::Favorite",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "provides" : {
     "MetaCPAN::Favorite" : "lib/MetaCPAN/Favorite.pm6"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license